### PR TITLE
Clean up the logic around the use of "lm" models for text2text tasks.

### DIFF
--- a/mesh_tensorflow/transformer/transformer.py
+++ b/mesh_tensorflow/transformer/transformer.py
@@ -781,7 +781,7 @@ class Unitransformer(object):
     weights = mtf.layers.weights_nonzero(
         targets, dtype=context.activation_dtype)
     if self.loss_on_targets_only:
-      weights *= mtf.cast(mtf.logical_not(text2self_inputs_mask(targets)),
+      weights *= mtf.cast(mtf.logical_not(delimited_lm_inputs_mask(targets)),
                           dtype=context.activation_dtype)
     return (mtf.reduce_sum(loss * weights) /
             self.loss_denominator(targets, context.num_microbatches))
@@ -957,7 +957,7 @@ class Unitransformer(object):
       position_is_default = False
     if self.input_full_attention:
       # The inputs part of each sequence can fully attend within itself.
-      full_attention_region = text2self_inputs_mask(targets)
+      full_attention_region = delimited_lm_inputs_mask(targets)
       # We can include one additional position to the right - the position
       #   where the final EOS of the inputs is read and the first target token
       #   is predicted.
@@ -1909,7 +1909,7 @@ def _round_up_to_multiple(n, divisor):
   return n + -n % divisor
 
 
-def text2self_inputs_mask(ids, eos_id=1):
+def delimited_lm_inputs_mask(ids, eos_id=1):
   """Binary mask indicating which parts of the ids represent the inputs.
 
   Assumes that the ids consist of packed sequences where each example is


### PR DESCRIPTION
We introduce a new "delimited_lm" model type, which indicates that a language model is being used for a text2text task (a task with inputs and targets).  The checkpoints are compatible, so a model can be trained as a "lm" model and fine-tuned as a "delimited_lm" model, or vice versa.
The difference is in input handling.  For a "delimited_lm" model we expect a task that produces inputs and targets.  We then construct the training sequence as [<inputs>, EOS, <targets>, EOS].  In inference mode, we seed the sequence with [<inputs>, EOS], and generate until another EOS is produced.
All of this functionality already existed, but the logic around when to use it was convoluted.

Also, remove the score_from_files() function and include its functionality in score_from_strings().

PiperOrigin-RevId: 314962508